### PR TITLE
Reset measurement system on model changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to BelowJS will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-01-07
+
+### Fixed
+- Measurement system now clears markers and resets targets when models change, ensuring measurement orbs remain usable after model switches
+
 ## [0.1.3] - 2025-01-01 - NPM Publication Ready
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -433,6 +433,7 @@ BelowJS includes a comprehensive measurement system for both VR and desktop envi
 - **Real-time Distance Display**: Live measurement updates with metric/imperial units
 - **Visual Feedback**: 3D spheres and lines showing measurement points and distances
 - **Model Integration**: Automatic target filtering to measure only model geometry
+- **Auto-Clear on Model Change**: Measurements reset when models are removed or switched
 - **Theming**: Dark and light theme support to match your application
 
 ### Enabling Measurements

--- a/src/viewers/ModelViewer.js
+++ b/src/viewers/ModelViewer.js
@@ -302,6 +302,14 @@ export class ModelViewer extends EventSystem {
       const modelRoot = this.belowViewer.loadedModels[0].model;
       this.measurementSystem.setRaycastTargets(modelRoot);
     }
+
+    // Reset measurements when models are cleared to keep measurement mode usable
+    this.belowViewer.on('models-cleared', () => {
+      if (this.measurementSystem) {
+        this.measurementSystem.clear();
+        this.measurementSystem.setTarget(null);
+      }
+    });
   }
 
   async _maybeAttachVRComfortGlyph() {


### PR DESCRIPTION
## Summary
- clear measurement markers and targets when models are cleared to keep orbs usable
- document automatic measurement reset on model change
- update changelog

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dc8679b4c8325a9eb9454d1a62db8