### PR TITLE
fix: restore VR controls after model switch

### DIFF
--- a/dist/belowjs.js
+++ b/dist/belowjs.js
@@ -8203,7 +8203,7 @@ class Dn extends yt {
     }
     this.currentModelKey = e, this.ui.dropdown && (this.ui.dropdown.value = e), this.showLoading(`Loading ${t.name || e}...`), document.title = `BelowJS – ${t.name || e}`;
     try {
-      this.measurementSystem && (this.measurementSystem.clearUnifiedMeasurement(), this.measurementSystem.clearLegacyVRMeasurement(), this.measurementSystem.clearLegacyDesktopMeasurement()), this.belowViewer.clearModels(), await new Promise((s) => setTimeout(s, 50));
+      this.measurementSystem && (this.measurementSystem.clearUnifiedMeasurement(), this.measurementSystem.clearLegacyVRMeasurement(), this.measurementSystem.clearLegacyDesktopMeasurement()), this.belowViewer.clearModels(), this.belowViewer.vrManager && (this.belowViewer.vrManager.stopMovement(), this.belowViewer.vrManager.resetTeleportState()), await new Promise((s) => setTimeout(s, 50));
       const i = await this.belowViewer.loadModel(t.url, {
         autoFrame: !1,
         // We'll handle positioning manually

--- a/src/viewers/ModelViewer.js
+++ b/src/viewers/ModelViewer.js
@@ -939,6 +939,15 @@ export class ModelViewer extends EventSystem {
 
       this.belowViewer.clearModels();
 
+      // When switching models while in VR, locomotion state can persist which
+      // leaves movement controls unresponsive in the next model. Explicitly
+      // reset VR movement systems after clearing the previous model so the
+      // new session starts fresh.
+      if (this.belowViewer.vrManager) {
+        this.belowViewer.vrManager.stopMovement();
+        this.belowViewer.vrManager.resetTeleportState();
+      }
+
       await new Promise(resolve => setTimeout(resolve, 50));
 
       const model = await this.belowViewer.loadModel(modelConfig.url, {


### PR DESCRIPTION
## Summary
- Reset VR locomotion and teleportation state when loading a new model so movement controls remain responsive.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a1e571ac88325a643d0801ada69c6