### PR TITLE
docs: remove model comparison guide links from examples page

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -238,11 +238,8 @@
             <h2>Model Comparison</h2>
             <p>Two-model GLB comparison tool with linked orbit views, paired control point alignment, single-view
                 time switching, and ICP-style refinement.</p>
-            <p class="example-note"><strong>Guide:</strong> See <a href="guides/model-comparison.html">Model Comparison</a>
-                for the typical workflow, point matching tips, export, and C2C inspection.</p>
             <div class="example-links">
                 <a href="examples/model-comparison/" target="_blank" class="button demo-btn">View Live Demo</a>
-                <a href="guides/model-comparison.html" class="button demo-btn" style="background: #059669;">Read Guide</a>
                 <a href="https://github.com/patrick-morrison/belowjs/tree/main/docs/examples/model-comparison"
                     target="_blank" class="button source-btn">Source Code</a>
                 <a href="https://raw.githubusercontent.com/patrick-morrison/belowjs/main/docs/examples/model-comparison/index.html"


### PR DESCRIPTION
### Motivation
- Remove the link to the Model Comparison guide from the Examples page so the example section no longer points to the guide.

### Description
- Deleted the inline “Guide” paragraph and the “Read Guide” button from the Model Comparison section in `docs/examples.html`, leaving the live demo and source/View HTML links intact.

### Testing
- Ran `npm run build` and `npm run lint` locally and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2cef06dc83259065aa345d7433a8)